### PR TITLE
Docs: add debounce for resize event handler (#17)

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -96,7 +96,9 @@
                   'iron-resize': '_onIronResize'
                 },
                 _onIronResize: function() {
-                  console.log('Resized');
+                  this.debounce('resizeDebounce', function() {
+                    console.log('Resized');
+                  }, 16); // Minimize CPU overhead by debouncing the handler
                 }
               });
             });


### PR DESCRIPTION
Related issue: #17 

Using a resize event handler without debouncing could be very CPU expensive. It's useful to mention debounce in docs IMO.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-split-layout/18)
<!-- Reviewable:end -->
