### PR TITLE
Don't depend on iron-flex-layout

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "polymer": "Polymer/polymer#^1.4.0",
-    "iron-flex-layout": "^1.3.1",
     "iron-icon": "^1.0.9",
     "iron-iconset-svg": "^1.0.9",
     "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^1.0.5"

--- a/vaadin-split-layout.html
+++ b/vaadin-split-layout.html
@@ -54,7 +54,6 @@ for the `iron-resize` event.
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../iron-icon/iron-icon.html">
 <link rel="import" href="../iron-iconset-svg/iron-iconset-svg.html">
 <link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
@@ -69,22 +68,23 @@ for the `iron-resize` event.
 <dom-module id="vaadin-split-layout">
   <template>
     <style>
-      :host(:not([vertical])) {
-        @apply(--layout-horizontal);
+      :host {
+        display: flex;
       }
 
       :host([vertical]) {
-        @apply(--layout-vertical);
+        flex-direction: column;
       }
 
       :host ::content > * {
-        @apply(--layout-flex-auto);
+        flex: 1 1 auto;
         overflow: auto;
       }
 
       #splitter {
-        @apply(--layout-center-justified);
-        @apply(--layout-flex-none);
+        display: flex;
+        justify-content: center;
+        flex: none;
         overflow: visible;
         min-height: 8px;
         min-width: 8px;
@@ -92,12 +92,11 @@ for the `iron-resize` event.
       }
 
       :host(:not([vertical])) > #splitter {
-        @apply(--layout-vertical);
+        flex-direction: column;
         cursor: ew-resize;
       }
 
       :host([vertical]) > #splitter {
-        @apply(--layout-horizontal);
         cursor: ns-resize;
       }
 


### PR DESCRIPTION
Shouldn't depend Vaadin core elements on iron-flex-layout (which basically is a higher level abstraction for flexbox), but #usetheplatform instead.

The PR is actually -2LOC so it doesn't add too much verbosity either.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-split-layout/20)
<!-- Reviewable:end -->
