### PR TITLE
Add overflow: hidden to vaadin-split-layout:host

### DIFF
--- a/vaadin-split-layout.html
+++ b/vaadin-split-layout.html
@@ -70,6 +70,7 @@ for the `iron-resize` event.
     <style>
       :host {
         display: flex;
+        overflow: hidden !important;
       }
 
       :host([vertical]) {


### PR DESCRIPTION
Fixes #26 

This will prevent scrollbars because of the splitter icon overflow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-split-layout/27)
<!-- Reviewable:end -->
