### PR TITLE
No need to prefix flex for the supported browsers

### DIFF
--- a/vaadin-split-layout.html
+++ b/vaadin-split-layout.html
@@ -175,9 +175,7 @@ Custom property | Description | Default
           // Pure zero does not play well in Safari
           flexBasis = 0.000001;
         }
-        ['-ms-flex', '-webkit-flex', 'flex'].forEach(function(prop) {
-          element.style[prop] = '1 1 ' + flexBasis + 'px';
-        });
+        element.style.flex = '1 1 ' + flexBasis + 'px';
       },
 
       _onHandleTrack: function(event) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-split-layout/30)
<!-- Reviewable:end -->
