### PR TITLE
Fix a typo/phrase in documentation. 📝

### DIFF
--- a/vaadin-split-layout.html
+++ b/vaadin-split-layout.html
@@ -81,7 +81,7 @@ example, the `<body>` is resized to fill the entire viewport, and the
 </body>
 ```
 
-Alternatively, you can place use flexbox layout make `<vaadin-split-layout>`
+Alternatively, you can use a flexbox layout to make `<vaadin-split-layout>`
 fill up the parent:
 
 ```html


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-split-layout/36)
<!-- Reviewable:end -->
