### PR TITLE
Bump Chrome and Edge versions for gemini tests

### DIFF
--- a/.gemini.yml
+++ b/.gemini.yml
@@ -12,7 +12,7 @@ browsers:
   chrome:
     desiredCapabilities:
       browserName: "chrome"
-      version: "54.0"
+      version: "57.0"
       platform: "Windows 10"
 
   firefox:
@@ -30,7 +30,7 @@ browsers:
   edge:
     desiredCapabilities:
       browserName: "microsoftedge"
-      version: "13"
+      version: "14"
       platform: "Windows 10"
 
 


### PR DESCRIPTION
Related to Anton's struggling with the `form-layout`: https://github.com/vaadin/vaadin-form-layout/tree/feature/styling-demo

Unfortunately, all Firefox versions after 47 (48-52) don't work with gemini.

Let's hope they will add Firefox support soon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-split-layout/59)
<!-- Reviewable:end -->
