### PR TITLE
Use translate3d for the rotated handle to avoid jumpiness

### DIFF
--- a/vaadin-split-layout.html
+++ b/vaadin-split-layout.html
@@ -226,7 +226,7 @@ element:
       }
 
       :host([vertical]) > #splitter #handle {
-        transform: translate(-50%, -50%) rotate(90deg);
+        transform: translate3d(-50%, -50%, 0) rotate(90deg);
       }
     </style>
     <slot id="primary" name="primary"></slot>


### PR DESCRIPTION
Fixes #66

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-split-layout/69)
<!-- Reviewable:end -->
