### PR TITLE
Fix setting `pointer-events: none`

### DIFF
--- a/test/vaadin-split-layout_test.html
+++ b/test/vaadin-split-layout_test.html
@@ -108,15 +108,15 @@
           expect(next.assignedNodes({flatten: true})[0] || next).to.equal(second);
         });
 
-        it('should set pointer-events: none to panels on start resize and restore after resize finished', () => {
+        it('should set pointer-events: none to panels on down event and restore on up event', () => {
           first.style.pointerEvents = 'visible';
           second.style.pointerEvents = 'visible';
 
-          Polymer.Base.fire('track', {state: 'start'}, {node: splitLayout.$.splitter});
+          Polymer.Base.fire('down', {}, {node: splitLayout.$.splitter});
           expect(getComputedStyle(first).pointerEvents).to.equal('none');
           expect(getComputedStyle(second).pointerEvents).to.equal('none');
 
-          Polymer.Base.fire('track', {state: 'end'}, {node: splitLayout.$.splitter});
+          Polymer.Base.fire('up', {}, {node: splitLayout.$.splitter});
           expect(getComputedStyle(first).pointerEvents).to.equal('visible');
           expect(getComputedStyle(second).pointerEvents).to.equal('visible');
         });

--- a/vaadin-split-layout.html
+++ b/vaadin-split-layout.html
@@ -78,7 +78,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     </style>
     <slot id="primary" name="primary"></slot>
-    <div part="splitter" id="splitter" on-track="_onHandleTrack" on-down="_preventDefault">
+    <div part="splitter" id="splitter" on-track="_onHandleTrack" on-down="_setPointerEventsNone" on-up="_restorePointerEvents">
       <div part="handle"></div>
     </div>
     <slot id="secondary" name="secondary"></slot>
@@ -285,6 +285,20 @@ This program is available under Apache License Version 2.0, available at https:/
           element.style.flex = '1 1 ' + flexBasis + 'px';
         }
 
+        _setPointerEventsNone(event) {
+          this._previousPrimaryPointerEvents = this._primaryChild.style.pointerEvents;
+          this._previousSecondaryPointerEvents = this._secondaryChild.style.pointerEvents;
+          this._primaryChild.style.pointerEvents = 'none';
+          this._secondaryChild.style.pointerEvents = 'none';
+
+          event.preventDefault();
+        }
+
+        _restorePointerEvents() {
+          this._primaryChild.style.pointerEvents = this._previousPrimaryPointerEvents;
+          this._secondaryChild.style.pointerEvents = this._previousSecondaryPointerEvents;
+        }
+
         _onHandleTrack(event) {
           if (!this._primaryChild || !this._secondaryChild) {
             return;
@@ -298,10 +312,6 @@ This program is available under Apache License Version 2.0, available at https:/
               secondary: this._secondaryChild.getBoundingClientRect()[size]
             };
 
-            this._previousPrimaryPointerEvents = this._primaryChild.style.pointerEvents;
-            this._previousSecondaryPointerEvents = this._secondaryChild.style.pointerEvents;
-            this._primaryChild.style.pointerEvents = 'none';
-            this._secondaryChild.style.pointerEvents = 'none';
             return;
           }
 
@@ -313,14 +323,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
           if (event.detail.state === 'end') {
             delete this._startSize;
-
-            this._primaryChild.style.pointerEvents = this._previousPrimaryPointerEvents;
-            this._secondaryChild.style.pointerEvents = this._previousSecondaryPointerEvents;
           }
-        }
-
-        _preventDefault(event) {
-          event.preventDefault();
         }
 
         /**

--- a/vaadin-split-layout.html
+++ b/vaadin-split-layout.html
@@ -5,6 +5,7 @@ This program is available under Apache License Version 2.0, available at https:/
 -->
 
 <link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="../polymer/lib/mixins/gesture-event-listeners.html">
 <link rel="import" href="../polymer/lib/utils/flattened-nodes-observer.html">
 <link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
 <link rel="import" href="../vaadin-themable-mixin/vaadin-themable-mixin.html">
@@ -227,9 +228,15 @@ This program is available under Apache License Version 2.0, available at https:/
        * `handle` | The handle of the splitter | vaadin-split-layout
        *
        * @memberof Vaadin
+       * @mixes Vaadin.ThemableMixin
+       * @mixes Polymer.GestureEventListeners
        * @demo demo/index.html
        */
-      class SplitLayoutElement extends Vaadin.ThemableMixin(Polymer.mixinBehaviors([Polymer.IronResizableBehavior], Polymer.Element)) {
+      class SplitLayoutElement extends
+        Vaadin.ThemableMixin(
+          Polymer.GestureEventListeners(
+            Polymer.mixinBehaviors([Polymer.IronResizableBehavior], Polymer.Element))) {
+
         static get is() {
           return 'vaadin-split-layout';
         }


### PR DESCRIPTION
We need to set `pointer-event: none` right away - in `on-down` handler. Before it was done in `track-start` handler, but `track-start` will not actually happen in some cases without `pointer-events: none`.

Fixes #80 #81

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-split-layout/83)
<!-- Reviewable:end -->
