### PR TITLE
Split vusial tests and unit tests into jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 dist: trusty
 language: node_js
-node_js: 8.0
+node_js: 8.1
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,20 +13,30 @@ addons:
 
 install:
   - npm install
-  - polymer install
+  - bower install
 
 before_script:
   - gulp lint
-  - polymer lint --rules polymer-2-hybrid --input *.html
+  - polymer lint --rules polymer-2 --input *.html
   - xvfb-run -s '-screen 0 1024x768x24' polymer test
+
+env:
+  - TEST_SUITE=visual_tests
+  - TEST_SUITE=unit_tests
 
 script:
   - if [[ "$TRAVIS_EVENT_TYPE" != "pull_request" && "$TRAVIS_BRANCH" != quick/* ]]; then
-      npm i --no-save gemini@^4.0.0 gemini-sauce gemini-polyserve &&
-      gemini test test/visual &&
-      gemini test test/visual -c .gemini-ie.yml &&
-      xvfb-run -s '-screen 0 1024x768x24' polymer test --env saucelabs;
+      if [[ "$TEST_SUITE" = "visual_tests" ]]; then
+        npm i --no-save gemini@^4.0.0 gemini-sauce gemini-polyserve &&
+        gemini test test/visual &&
+        gemini test test/visual -c .gemini-ie.yml;
+      fi;
+      if [[ "$TEST_SUITE" = "unit_tests" ]]; then
+        xvfb-run -s '-screen 0 1024x768x24' polymer test --env saucelabs;
+      fi;
     fi
-  - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
-      xvfb-run -s '-screen 0 1024x768x24' polymer test --env saucelabs-cron;
+  - if [[ "$TRAVIS_EVENT_TYPE" = "cron" ]]; then
+      if [[ "$TEST_SUITE" = "visual_tests" ]]; then
+        xvfb-run -s '-screen 0 1024x768x24' polymer test --env saucelabs-cron;
+      fi;
     fi

--- a/bower.json
+++ b/bower.json
@@ -30,10 +30,6 @@
     "iron-test-helpers": "^2.0.0",
     "paper-button": "^2.0.0",
     "web-component-tester": "^6.1.5",
-    "webcomponentsjs": "^v1.0.0-rc.11",
     "vaadin-demo-helpers": "^1.0.0"
-  },
-  "resolutions": {
-    "webcomponentsjs": "^v1.0.0-rc.11"
   }
 }


### PR DESCRIPTION
In case of `split-layout` we will save 2-3 munites per build.

Also, in case of `timeout` dev would need to restart only related tests without retriggering everything.

Related skeleton change: https://github.com/vaadin/vaadin-element-skeleton/pull/65

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-split-layout/84)
<!-- Reviewable:end -->
