### PR TITLE
Redesign Lumo variants

### DIFF
--- a/demo/split-layout-basic-demos.html
+++ b/demo/split-layout-basic-demos.html
@@ -8,7 +8,7 @@
 
 
     <h3>Horizontal Split Layout (Default)</h3>
-    <vaadin-demo-snippet id='split-layout-basic-demos-horizontal-split-layout-default'>
+    <vaadin-demo-snippet id="split-layout-basic-demos-horizontal-split-layout-default">
       <template preserve-content>
         <vaadin-split-layout>
           <div>First content element</div>
@@ -19,7 +19,7 @@
 
 
     <h3>Vertical Split Layout</h3>
-    <vaadin-demo-snippet id='split-layout-basic-demos-vertical-split-layout'>
+    <vaadin-demo-snippet id="split-layout-basic-demos-vertical-split-layout">
       <template preserve-content>
         <vaadin-split-layout orientation="vertical">
           <div>Top content element</div>
@@ -30,7 +30,7 @@
 
 
     <h3>Layout Combination</h3>
-    <vaadin-demo-snippet id='split-layout-basic-demos-layout-combination'>
+    <vaadin-demo-snippet id="split-layout-basic-demos-layout-combination">
       <template preserve-content>
         <vaadin-split-layout>
           <div>First content element</div>
@@ -46,7 +46,7 @@
     <h3>Split Layout Element Height</h3>
 
     <h4>Using Fixed Height</h4>
-    <vaadin-demo-snippet id='split-layout-basic-demos-split-layout-element-height'>
+    <vaadin-demo-snippet id="split-layout-basic-demos-split-layout-element-height">
       <template preserve-content>
         <vaadin-split-layout style="height: 200px;">
           <div>First content element</div>
@@ -56,7 +56,7 @@
     </vaadin-demo-snippet>
 
     <h4>Using Relative Height</h4>
-    <vaadin-demo-snippet id='split-layout-basic-demos-split-layout-element-height'>
+    <vaadin-demo-snippet id="split-layout-basic-demos-split-layout-element-height">
       <template preserve-content>
         <div style="height: 200px;">
           <vaadin-split-layout style="height: 100%;">
@@ -68,7 +68,7 @@
     </vaadin-demo-snippet>
 
     <h4>Using Flexbox Layout</h4>
-    <vaadin-demo-snippet id='split-layout-basic-demos-split-layout-element-height'>
+    <vaadin-demo-snippet id="split-layout-basic-demos-split-layout-element-height">
       <template preserve-content>
         <div style="height: 160px; display: flex;">
           <vaadin-split-layout style="flex: 1;">
@@ -81,7 +81,7 @@
 
 
     <h3>Initial Splitter Position</h3>
-    <vaadin-demo-snippet id='split-layout-basic-demos-initial-splitter-position'>
+    <vaadin-demo-snippet id="split-layout-basic-demos-initial-splitter-position">
       <template preserve-content>
         <vaadin-split-layout>
           <div style="width: 75%;">First</div>
@@ -92,7 +92,7 @@
 
 
     <h3>Specifying Min- and Max- Sizes</h3>
-    <vaadin-demo-snippet id='split-layout-basic-demos-specifying-min--and-max--sizes'>
+    <vaadin-demo-snippet id="split-layout-basic-demos-specifying-min--and-max--sizes">
       <template preserve-content>
         <vaadin-split-layout>
           <div style="min-width: 50px; max-width: 150px;">First</div>
@@ -103,7 +103,7 @@
 
 
     <h3>Resize Notification for the Nested Elements</h3>
-    <vaadin-demo-snippet id='split-layout-basic-demos-resize-notification-for-the-nested-elements'>
+    <vaadin-demo-snippet id="split-layout-basic-demos-resize-notification-for-the-nested-elements">
       <template preserve-content>
         <vaadin-split-layout>
           <div>First</div>

--- a/demo/split-layout-integration-demos.html
+++ b/demo/split-layout-integration-demos.html
@@ -8,7 +8,7 @@
 
 
     <h3>Google Maps</h3>
-    <vaadin-demo-snippet id='split-layout-integration-demos-google-maps'>
+    <vaadin-demo-snippet id="split-layout-integration-demos-google-maps">
       <template preserve-content>
         <custom-style>
           <style is="custom-style">

--- a/demo/split-layout-lumo-theme-demos.html
+++ b/demo/split-layout-lumo-theme-demos.html
@@ -7,7 +7,7 @@
     </style>
 
     <h3>Small</h3>
-    <vaadin-demo-snippet id='split-layout-lumo-theme-demos-small'>
+    <vaadin-demo-snippet id="split-layout-lumo-theme-demos-small">
       <template preserve-content>
         <style>
           vaadin-split-layout {
@@ -35,7 +35,7 @@
     </vaadin-demo-snippet>
 
     <h3>Minimal</h3>
-    <vaadin-demo-snippet id='split-layout-lumo-theme-demos-minimal'>
+    <vaadin-demo-snippet id="split-layout-lumo-theme-demos-minimal">
       <template preserve-content>
         <style>
           vaadin-split-layout {

--- a/demo/split-layout-lumo-theme-demos.html
+++ b/demo/split-layout-lumo-theme-demos.html
@@ -6,29 +6,6 @@
       }
     </style>
 
-    <h3>Default</h3>
-    <vaadin-demo-snippet id='split-layout-lumo-theme-demos-default'>
-      <template preserve-content>
-        <style>
-          vaadin-split-layout {
-            min-height: 200px;
-            flex: auto;
-          }
-        </style>
-        <div style="display: flex">
-          <vaadin-split-layout>
-            <div></div>
-            <div></div>
-          </vaadin-split-layout>
-
-          <vaadin-split-layout orientation="vertical">
-            <div></div>
-            <div></div>
-          </vaadin-split-layout>
-        </div>
-      </template>
-    </vaadin-demo-snippet>
-
     <h3>Small</h3>
     <vaadin-demo-snippet id='split-layout-lumo-theme-demos-small'>
       <template preserve-content>
@@ -36,6 +13,9 @@
           vaadin-split-layout {
             min-height: 200px;
             flex: auto;
+          }
+          div:first-child {
+            background-color: var(--lumo-shade-5pct);
           }
         </style>
         <div style="display: flex">
@@ -53,22 +33,25 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Subtle</h3>
-    <vaadin-demo-snippet id='split-layout-lumo-theme-demos-subtle'>
+    <h3>Minimal</h3>
+    <vaadin-demo-snippet id='split-layout-lumo-theme-demos-minimal'>
       <template preserve-content>
         <style>
           vaadin-split-layout {
             min-height: 200px;
             flex: auto;
           }
+          div:first-child {
+            background-color: var(--lumo-shade-5pct);
+          }
         </style>
         <div style="display: flex">
-          <vaadin-split-layout theme="subtle">
+          <vaadin-split-layout theme="minimal">
             <div></div>
             <div></div>
           </vaadin-split-layout>
 
-          <vaadin-split-layout orientation="vertical" theme="subtle">
+          <vaadin-split-layout orientation="vertical" theme="minimal">
             <div></div>
             <div></div>
           </vaadin-split-layout>

--- a/demo/split-layout-lumo-theme-demos.html
+++ b/demo/split-layout-lumo-theme-demos.html
@@ -14,20 +14,16 @@
             min-height: 200px;
             flex: auto;
           }
-
-          div:first-child {
-            background-color: var(--lumo-shade-5pct);
-          }
         </style>
         <div style="display: flex">
           <vaadin-split-layout theme="small">
-            <div></div>
-            <div></div>
+            <div>First content element</div>
+            <div>Second content element</div>
           </vaadin-split-layout>
 
           <vaadin-split-layout orientation="vertical" theme="small">
-            <div></div>
-            <div></div>
+            <div>First content element</div>
+            <div>Second content element</div>
           </vaadin-split-layout>
         </div>
 
@@ -42,20 +38,16 @@
             min-height: 200px;
             flex: auto;
           }
-
-          div:first-child {
-            background-color: var(--lumo-shade-5pct);
-          }
         </style>
         <div style="display: flex">
           <vaadin-split-layout theme="minimal">
-            <div></div>
-            <div></div>
+            <div style="background-color: lightgray;">Custom background color</div>
+            <div>Second content element</div>
           </vaadin-split-layout>
 
           <vaadin-split-layout orientation="vertical" theme="minimal">
-            <div></div>
-            <div></div>
+            <div style="background-color: lightgray;">Custom background color</div>
+            <div>Second content element</div>
           </vaadin-split-layout>
         </div>
 

--- a/demo/split-layout-lumo-theme-demos.html
+++ b/demo/split-layout-lumo-theme-demos.html
@@ -14,6 +14,7 @@
             min-height: 200px;
             flex: auto;
           }
+
           div:first-child {
             background-color: var(--lumo-shade-5pct);
           }
@@ -41,6 +42,7 @@
             min-height: 200px;
             flex: auto;
           }
+
           div:first-child {
             background-color: var(--lumo-shade-5pct);
           }

--- a/theme/lumo/vaadin-split-layout.html
+++ b/theme/lumo/vaadin-split-layout.html
@@ -14,27 +14,28 @@
       }
 
       [part="handle"] {
+        display: flex;
+        align-items: center;
+        justify-content: center;
         width: var(--lumo-size-m);
         height: var(--lumo-size-m);
       }
 
       [part="handle"]::after {
         content: "";
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 45%;
-        right: 45%;
+        display: block;
+        width: 4px;
+        height: 100%;
+        max-width: 100%;
+        max-height: 100%;
         border-radius: var(--lumo-border-radius);
         background-color: var(--lumo-contrast-30pct);
-        transition: 0.1s all;
+        transition: 0.1s opacity, 0.1s background-color;
       }
 
       :host([orientation="vertical"]) [part="handle"]::after {
-        left: 0;
-        right: 0;
-        top: 45%;
-        bottom: 45%;
+        width: 100%;
+        height: 4px;
       }
 
       /* Hover style */
@@ -59,11 +60,11 @@
       /* Small/minimal */
 
       :host([theme~="small"]) > [part="splitter"] {
-        min-width: 1px;
-        min-height: 1px;
-        background-color: var(--lumo-contrast-10pct);
+        border-left: 1px solid var(--lumo-contrast-10pct);
+        border-top: 1px solid var(--lumo-contrast-10pct);
       }
 
+      :host([theme~="small"]) > [part="splitter"],
       :host([theme~="minimal"]) > [part="splitter"] {
         min-width: 0;
         min-height: 0;

--- a/theme/lumo/vaadin-split-layout.html
+++ b/theme/lumo/vaadin-split-layout.html
@@ -6,35 +6,35 @@
 <dom-module id="lumo-split-layout" theme-for="vaadin-split-layout">
   <template>
     <style>
-      :host {
-        --lumo-split-layout-size: var(--lumo-space-s);
-      }
-
       [part="splitter"] {
-        min-width: var(--lumo-split-layout-size);
-        min-height: var(--lumo-split-layout-size);
+        min-width: var(--lumo-space-s);
+        min-height: var(--lumo-space-s);
         background-color: var(--lumo-contrast-5pct);
         transition: 0.1s background-color;
       }
 
       [part="handle"] {
-        display: flex;
-        align-items: center;
-        justify-content: center;
+        width: var(--lumo-size-m);
+        height: var(--lumo-size-m);
       }
 
       [part="handle"]::after {
         content: "";
-        display: block;
-        width: var(--lumo-space-xs);
-        height: var(--lumo-size-s);
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 45%;
+        right: 45%;
         border-radius: var(--lumo-border-radius);
         background-color: var(--lumo-contrast-30pct);
-        transition: 0.1s background-color;
+        transition: 0.1s all;
       }
 
       :host([orientation="vertical"]) [part="handle"]::after {
-        transform: rotate(90deg);
+        left: 0;
+        right: 0;
+        top: 45%;
+        bottom: 45%;
       }
 
       /* Hover style */
@@ -56,20 +56,40 @@
         background-color: var(--lumo-contrast-50pct);
       }
 
-      /* Small style */
+      /* Small/minimal */
 
-      :host([theme~="small"]) {
-        --lumo-split-layout-size: var(--lumo-space-xs);
+      :host([theme~="small"]) > [part="splitter"] {
+        min-width: 1px;
+        min-height: 1px;
+        background-color: var(--lumo-contrast-10pct);
       }
 
-      :host([theme~="small"]) [part="handle"]::after {
-        width: calc(var(--lumo-space-xs) / 2);
-      }
-
-      /* Subtle style */
-
-      :host([theme~="subtle"]) [part="splitter"] {
+      :host([theme~="minimal"]) > [part="splitter"] {
+        min-width: 0;
+        min-height: 0;
         background-color: transparent;
+      }
+
+      :host([theme~="small"]) > [part="splitter"]::after,
+      :host([theme~="minimal"]) > [part="splitter"]::after {
+        content: "";
+        position: absolute;
+        top: -4px;
+        right: -4px;
+        bottom: -4px;
+        left: -4px;
+      }
+
+      :host([theme~="small"]) > [part="splitter"] > [part="handle"]::after,
+      :host([theme~="minimal"]) > [part="splitter"] > [part="handle"]::after {
+        opacity: 0;
+      }
+
+      :host([theme~="small"]) > [part="splitter"]:hover > [part="handle"]::after,
+      :host([theme~="small"]) > [part="splitter"]:active > [part="handle"]::after,
+      :host([theme~="minimal"]) > [part="splitter"]:hover > [part="handle"]::after,
+      :host([theme~="minimal"]) > [part="splitter"]:active > [part="handle"]::after {
+        opacity: 1;
       }
     </style>
   </template>


### PR DESCRIPTION
Base the size of the handle in sizing properties instead of space properties.

Redesigned “small” variant – now just 1px divider and the handle is only visible on hover. The handle is now always the same size for normal and small, only the splitter part changes.

Rename “subtle” to “minimal” (align with other element variant names). The minimal variant doesn’t have any visible splitter, and the handle is only visible on hover.

Update demos to reflect the changes.

This is a breaking change, so I wanted to discuss this with a pull request before merging. The motivation for doing this change came from the “kitchen sink” test app that I built in the vaadin-lumo-styles repo, and these styles made the most sense for a clean application layout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-split-layout/100)
<!-- Reviewable:end -->
