### PR TITLE
Use bare module specifiers in the P3 conversion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
       npm install -g yarn magi-cli polymer-cli@next &&
       (cd .. && git clone --depth 1 -b vaadin-components git://github.com/web-padawan/polymer-modulizer.git && cd polymer-modulizer && npm link) &&
       rm -rf node_modules &&
-      magi p3-convert --out . &&
+      magi p3-convert --out . --import-style=name &&
       yarn install --flat &&
       if [[ "$TRAVIS_EVENT_TYPE" = "pull_request" ]]; then
         xvfb-run -s '-screen 0 1024x768x24' polymer test --module-resolution=node --npm -l chrome;

--- a/test/vaadin-split-layout_test.html
+++ b/test/vaadin-split-layout_test.html
@@ -114,11 +114,13 @@
           first.style.pointerEvents = 'visible';
           second.style.pointerEvents = 'visible';
 
-          Polymer.Base.fire('down', {}, {node: splitLayout.$.splitter});
+          const splitter = splitLayout.$.splitter;
+
+          splitter.dispatchEvent(new Event('down', {bubbles: true}));
           expect(getComputedStyle(first).pointerEvents).to.equal('none');
           expect(getComputedStyle(second).pointerEvents).to.equal('none');
 
-          Polymer.Base.fire('up', {}, {node: splitLayout.$.splitter});
+          splitter.dispatchEvent(new Event('up', {bubbles: true}));
           expect(getComputedStyle(first).pointerEvents).to.equal('visible');
           expect(getComputedStyle(second).pointerEvents).to.equal('visible');
         });

--- a/test/vaadin-split-layout_test.html
+++ b/test/vaadin-split-layout_test.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
     <script src="../../web-component-tester/browser.js"></script>
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <link rel="import" href="../../test-fixture/test-fixture.html">
     <link rel="import" href="../../iron-test-helpers/mock-interactions.html">
     <link rel="import" href="../vaadin-split-layout.html">
   </head>

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -18,7 +18,9 @@ module.exports = {
       'macOS 10.12/iphone@11.2',
       'macOS 10.12/ipad@11.2',
       'Windows 10/chrome@65',
-      'macOS 10.12/safari@11.0'
+      'macOS 10.12/safari@11.0',
+      'Windows 10/firefox@59',
+      'Windows 10/microsoftedge@16'
     ];
 
     var cronPlatforms = [


### PR DESCRIPTION
Connected to vaadin/components-team-tasks#332

Also did some cleanup to eliminate the single legacy `Polymer.Base` usage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-split-layout/106)
<!-- Reviewable:end -->
