### PR TITLE
Reorganize demos

### DIFF
--- a/demo/demos.json
+++ b/demo/demos.json
@@ -2,14 +2,25 @@
   "name": "Vaadin Split Layout",
   "pages": [
   {
-    "name": "Basic Examples",
+    "name": "Basics",
     "url": "split-layout-basic-demos",
     "src": "split-layout-basic-demos.html",
     "meta": {
       "title": "vaadin-split-layout Basic Examples",
       "description": "",
       "image": ""
-     }
+    }
+  }
+  ,
+  {
+    "name": "Height",
+    "url": "split-layout-height-demos",
+    "src": "split-layout-height-demos.html",
+    "meta": {
+      "title": "vaadin-split-layout Height Examples",
+      "description": "",
+      "image": ""
+    }
   }
   ,
   {
@@ -20,18 +31,18 @@
       "title": "vaadin-split-layout Integration",
       "description": "",
       "image": ""
-     }
+    }
   }
   ,
   {
-    "name": "Lumo Theme Variations",
-    "url": "split-layout-lumo-theme-demos",
-    "src": "split-layout-lumo-theme-demos.html",
+    "name": "Theme Variants",
+    "url": "split-layout-theme-demos",
+    "src": "split-layout-theme-demos.html",
     "meta": {
-      "title": "vaadin-split-layout Lumo Theme Variations",
+      "title": "vaadin-split-layout Theme Variants",
       "description": "",
       "image": ""
-     }
+    }
   }
   ]
 }

--- a/demo/split-layout-basic-demos.html
+++ b/demo/split-layout-basic-demos.html
@@ -43,43 +43,6 @@
     </vaadin-demo-snippet>
 
 
-    <h3>Split Layout Element Height</h3>
-
-    <h4>Using Fixed Height</h4>
-    <vaadin-demo-snippet id="split-layout-basic-demos-split-layout-element-height">
-      <template preserve-content>
-        <vaadin-split-layout style="height: 200px;">
-          <div>First content element</div>
-          <div>Second content element</div>
-        </vaadin-split-layout>
-      </template>
-    </vaadin-demo-snippet>
-
-    <h4>Using Relative Height</h4>
-    <vaadin-demo-snippet id="split-layout-basic-demos-split-layout-element-height">
-      <template preserve-content>
-        <div style="height: 200px;">
-          <vaadin-split-layout style="height: 100%;">
-            <div>First</div>
-            <div>Second</div>
-          </vaadin-split-layout>
-        </div>
-      </template>
-    </vaadin-demo-snippet>
-
-    <h4>Using Flexbox Layout</h4>
-    <vaadin-demo-snippet id="split-layout-basic-demos-split-layout-element-height">
-      <template preserve-content>
-        <div style="height: 160px; display: flex;">
-          <vaadin-split-layout style="flex: 1;">
-            <div>First</div>
-            <div>Second</div>
-          </vaadin-split-layout>
-        </div>
-      </template>
-    </vaadin-demo-snippet>
-
-
     <h3>Initial Splitter Position</h3>
     <vaadin-demo-snippet id="split-layout-basic-demos-initial-splitter-position">
       <template preserve-content>
@@ -101,32 +64,6 @@
       </template>
     </vaadin-demo-snippet>
 
-
-    <h3>Resize Notification for the Nested Elements</h3>
-    <vaadin-demo-snippet id="split-layout-basic-demos-resize-notification-for-the-nested-elements">
-      <template preserve-content>
-        <vaadin-split-layout>
-          <div>First</div>
-          <custom-resizable>Second</custom-resizable>
-        </vaadin-split-layout>
-        <script>
-        window.addDemoReadyListener('#split-layout-basic-demos-resize-notification-for-the-nested-elements', function(document) {
-          Polymer({
-            is: 'custom-resizable',
-            behaviors: [
-              Polymer.IronResizableBehavior
-            ],
-            listeners: {
-              'iron-resize': '_onIronResize'
-            },
-            _onIronResize: function() {
-              console.log('Resized');
-            }
-          });
-        });
-        </script>
-      </template>
-    </vaadin-demo-snippet>
 
   </template>
   <script>

--- a/demo/split-layout-height-demos.html
+++ b/demo/split-layout-height-demos.html
@@ -8,7 +8,7 @@
 
 
     <h3>Fixed Height</h3>
-    <vaadin-demo-snippet id="split-layout-height-demos-split-layout-element-height">
+    <vaadin-demo-snippet id="split-layout-height-demos-height-fixed-height">
       <template preserve-content>
         <vaadin-split-layout style="height: 200px;">
           <div>First content element</div>
@@ -18,7 +18,7 @@
     </vaadin-demo-snippet>
 
     <h3>Relative Height</h3>
-    <vaadin-demo-snippet id="split-layout-height-demos-split-layout-element-height">
+    <vaadin-demo-snippet id="split-layout-height-demos-height-relative-height">
       <template preserve-content>
         <div style="height: 200px;">
           <vaadin-split-layout style="height: 100%;">
@@ -30,7 +30,7 @@
     </vaadin-demo-snippet>
 
     <h3>Flexbox Layout</h3>
-    <vaadin-demo-snippet id="split-layout-height-demos-split-layout-element-height">
+    <vaadin-demo-snippet id="split-layout-height-demos-height-flexbox-layout">
       <template preserve-content>
         <div style="height: 160px; display: flex;">
           <vaadin-split-layout style="flex: 1;">

--- a/demo/split-layout-height-demos.html
+++ b/demo/split-layout-height-demos.html
@@ -1,0 +1,54 @@
+<dom-module id="split-layout-height-demos">
+  <template>
+    <style include="vaadin-component-demo-shared-styles">
+      :host {
+        display: block;
+      }
+    </style>
+
+
+    <h3>Fixed Height</h3>
+    <vaadin-demo-snippet id="split-layout-height-demos-split-layout-element-height">
+      <template preserve-content>
+        <vaadin-split-layout style="height: 200px;">
+          <div>First content element</div>
+          <div>Second content element</div>
+        </vaadin-split-layout>
+      </template>
+    </vaadin-demo-snippet>
+
+    <h3>Relative Height</h3>
+    <vaadin-demo-snippet id="split-layout-height-demos-split-layout-element-height">
+      <template preserve-content>
+        <div style="height: 200px;">
+          <vaadin-split-layout style="height: 100%;">
+            <div>First</div>
+            <div>Second</div>
+          </vaadin-split-layout>
+        </div>
+      </template>
+    </vaadin-demo-snippet>
+
+    <h3>Flexbox Layout</h3>
+    <vaadin-demo-snippet id="split-layout-height-demos-split-layout-element-height">
+      <template preserve-content>
+        <div style="height: 160px; display: flex;">
+          <vaadin-split-layout style="flex: 1;">
+            <div>First</div>
+            <div>Second</div>
+          </vaadin-split-layout>
+        </div>
+      </template>
+    </vaadin-demo-snippet>
+
+
+  </template>
+  <script>
+    class SplitLayoutHeightDemos extends DemoReadyEventEmitter(SplitLayoutDemo(Polymer.Element)) {
+      static get is() {
+        return 'split-layout-height-demos';
+      }
+    }
+    customElements.define(SplitLayoutHeightDemos.is, SplitLayoutHeightDemos);
+  </script>
+</dom-module>

--- a/demo/split-layout-integration-demos.html
+++ b/demo/split-layout-integration-demos.html
@@ -25,6 +25,34 @@
       </template>
     </vaadin-demo-snippet>
 
+    <h3>Resize Notification for the Nested Elements</h3>
+    <vaadin-demo-snippet id="split-layout-basic-integration-resize-notification-for-the-nested-elements">
+      <template preserve-content>
+        <vaadin-split-layout>
+          <div>First</div>
+          <custom-resizable>Second</custom-resizable>
+        </vaadin-split-layout>
+        <script>
+        window.addDemoReadyListener('#split-layout-basic-integration-resize-notification-for-the-nested-elements', function(document) {
+          if (!window.customElements.get('custom-resizable')) {
+            Polymer({
+              is: 'custom-resizable',
+              behaviors: [
+                Polymer.IronResizableBehavior
+              ],
+              listeners: {
+                'iron-resize': '_onIronResize'
+              },
+              _onIronResize: function() {
+                console.log('Resized');
+              }
+            });
+          }
+        });
+        </script>
+      </template>
+    </vaadin-demo-snippet>
+
   </template>
   <script>
     class SplitLayoutIntegrationDemos extends DemoReadyEventEmitter(SplitLayoutDemo(Polymer.Element)) {

--- a/demo/split-layout-theme-demos.html
+++ b/demo/split-layout-theme-demos.html
@@ -1,4 +1,4 @@
-<dom-module id="split-layout-lumo-theme-demos">
+<dom-module id="split-layout-theme-demos">
   <template>
     <style include="vaadin-component-demo-shared-styles">
       :host {
@@ -7,7 +7,7 @@
     </style>
 
     <h3>Small</h3>
-    <vaadin-demo-snippet id="split-layout-lumo-theme-demos-small">
+    <vaadin-demo-snippet id="split-layout-theme-demos-small">
       <template preserve-content>
         <style>
           vaadin-split-layout {
@@ -31,7 +31,7 @@
     </vaadin-demo-snippet>
 
     <h3>Minimal</h3>
-    <vaadin-demo-snippet id="split-layout-lumo-theme-demos-minimal">
+    <vaadin-demo-snippet id="split-layout-theme-demos-minimal">
       <template preserve-content>
         <style>
           vaadin-split-layout {
@@ -56,11 +56,11 @@
 
   </template>
   <script>
-    class SplitLayoutLumoThemeDemos extends DemoReadyEventEmitter(SplitLayoutDemo(Polymer.Element)) {
+    class SplitLayoutThemeDemos extends DemoReadyEventEmitter(SplitLayoutDemo(Polymer.Element)) {
       static get is() {
-        return 'split-layout-lumo-theme-demos';
+        return 'split-layout-theme-demos';
       }
     }
-    customElements.define(SplitLayoutLumoThemeDemos.is, SplitLayoutLumoThemeDemos);
+    customElements.define(SplitLayoutThemeDemos.is, SplitLayoutThemeDemos);
   </script>
 </dom-module>


### PR DESCRIPTION
Connects to "Guidelines for component examples"
- Renamed "Basic Examples" to "Basics" as it is in other components
- Created "Height" demo page and moved height related demos there
- Renamed "Lumo Theme Variations" to "Theme Variants"
- Moved "Resize Notification" to Integrations

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-split-layout/116)
<!-- Reviewable:end -->
