### PR TITLE
Add title to iframes in demos [skip ci]

### DIFF
--- a/demo/split-layout-integration-demos.html
+++ b/demo/split-layout-integration-demos.html
@@ -19,8 +19,8 @@
           </style>
         </custom-style>
         <vaadin-split-layout style="height: 300px">
-          <iframe src="//maps.google.com/maps?q=Turku&amp;output=embed"></iframe>
-          <iframe src="//maps.google.com/maps?q=Malta&amp;output=embed"></iframe>
+          <iframe src="//maps.google.com/maps?q=Turku&amp;output=embed" title="Map of Turku"></iframe>
+          <iframe src="//maps.google.com/maps?q=Malta&amp;output=embed" title="Map of Malta"></iframe>
         </vaadin-split-layout>
       </template>
     </vaadin-demo-snippet>


### PR DESCRIPTION
A11Y improvement to demos: Iframe should have `title` attribute: https://dequeuniversity.com/rules/axe/2.2/frame-title?application=lighthouse

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-split-layout/122)
<!-- Reviewable:end -->
