### PR TITLE
fix: do not throw when layout has only one child

### DIFF
--- a/src/vaadin-split-layout.html
+++ b/src/vaadin-split-layout.html
@@ -281,6 +281,9 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _setPointerEventsNone(event) {
+          if (!this._primaryChild || !this._secondaryChild) {
+            return;
+          }
           this._previousPrimaryPointerEvents = this._primaryChild.style.pointerEvents;
           this._previousSecondaryPointerEvents = this._secondaryChild.style.pointerEvents;
           this._primaryChild.style.pointerEvents = 'none';
@@ -290,6 +293,9 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _restorePointerEvents() {
+          if (!this._primaryChild || !this._secondaryChild) {
+            return;
+          }
           this._primaryChild.style.pointerEvents = this._previousPrimaryPointerEvents;
           this._secondaryChild.style.pointerEvents = this._previousSecondaryPointerEvents;
         }

--- a/test/vaadin-split-layout_test.html
+++ b/test/vaadin-split-layout_test.html
@@ -22,6 +22,14 @@
       </template>
     </test-fixture>
 
+    <test-fixture id="one-child-layout">
+      <template>
+        <vaadin-split-layout>
+          <div id="first">some content</div>
+        </vaadin-split-layout>
+      </template>
+    </test-fixture>
+
     <script>
       var touchDevice = (() => {
         try {
@@ -126,6 +134,28 @@
           expect(getComputedStyle(second).pointerEvents).to.equal('visible');
         });
 
+      });
+
+      describe('layout with one child', () => {
+
+        beforeEach(done => {
+          splitLayout = fixture('one-child-layout');
+          setTimeout(() => {
+            first = splitLayout.$.primary.assignedNodes({flatten: true})[0];
+            done();
+          }, 1);
+        });
+
+        it('does not throw when setting and removing pointer-events', () => {
+          const splitter = splitLayout.$.splitter;
+
+          const downAndUp = () => {
+            splitter.dispatchEvent(new Event('down', {bubbles: true}));
+            splitter.dispatchEvent(new Event('up', {bubbles: true}));
+          };
+
+          expect(downAndUp).to.not.throw(Error);
+        });
       });
 
       describe('splitter', () => {

--- a/test/visual/customized.html
+++ b/test/visual/customized.html
@@ -10,7 +10,7 @@
 </head>
 
 <body>
-  <dom-module id="vaadin-split-layout-styles" theme-for="vaadin-split-layout">
+  <dom-module id="custom-split-layout-styles" theme-for="vaadin-split-layout">
     <template>
       <style>
         [part~="splitter"] {


### PR DESCRIPTION
Fixes #123 

There is already such a check in `_onHandleTrack` listener. Let's add it in other listeners, too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-split-layout/128)
<!-- Reviewable:end -->
