### PR TITLE
feat: prepare for TS defs generation [skip ci]

### DIFF
--- a/@types/interfaces.d.ts
+++ b/@types/interfaces.d.ts
@@ -1,0 +1,1 @@
+export type SplitLayoutOrientation = 'horizontal' | 'vertical';

--- a/bower.json
+++ b/bower.json
@@ -32,10 +32,10 @@
   "dependencies": {
     "polymer": "^2.0.0",
     "iron-resizable-behavior": "^2.0.0",
-    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.2.1",
+    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.6.1",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.1.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.1.0",
-    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.3.0"
+    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.4.1"
   },
   "devDependencies": {
     "iron-component-page": "^3.0.0",

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,9 @@
+{
+  "excludeFiles": [
+    "wct.conf.js",
+    "index.html",
+    "demo/**/*",
+    "test/**/*",
+    "theme/**/*"
+  ]
+}

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -5,5 +5,10 @@
     "demo/**/*",
     "test/**/*",
     "theme/**/*"
-  ]
+  ],
+  "autoImport": {
+    "./@types/interfaces": [
+      "SplitLayoutOrientation"
+    ]
+  }
 }

--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -1,0 +1,11 @@
+module.exports = {
+  files: [
+    'vaadin-split-layout.js'
+  ],
+  from: [
+    /import '\.\/theme\/lumo\/vaadin-(.+)\.js';/
+  ],
+  to: [
+    `import './theme/lumo/vaadin-$1.js';\nexport * from './src/vaadin-$1.js';`
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://vaadin.com/components",
   "files": [
+    "vaadin-*.d.ts",
     "vaadin-*.js",
     "src",
     "theme"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "files": [
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "@types",
     "src",
     "theme"
   ],

--- a/src/vaadin-split-layout.html
+++ b/src/vaadin-split-layout.html
@@ -344,6 +344,14 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         /**
+         * Can be called to manually notify a resizable and its descendant
+         * resizables of a resize change.
+         */
+        notifyResize() {
+          super.notifyResize();
+        }
+
+        /**
          * Fired when the splitter is dragged. Non-bubbling. Fired for the splitter
          * element and any nested elements with `IronResizableBehavior`.
          *

--- a/src/vaadin-split-layout.html
+++ b/src/vaadin-split-layout.html
@@ -348,6 +348,8 @@ This program is available under Apache License Version 2.0, available at https:/
          * resizables of a resize change.
          */
         notifyResize() {
+          // NOTE: we have this method here to include it to TypeScript definitions.
+          // gen-typescript-declarations does not generate types for `mixinBehaviors`
           super.notifyResize();
         }
 

--- a/src/vaadin-split-layout.html
+++ b/src/vaadin-split-layout.html
@@ -218,6 +218,7 @@ This program is available under Apache License Version 2.0, available at https:/
        * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
        *
        * @memberof Vaadin
+       * @mixes Vaadin.ElementMixin
        * @mixes Vaadin.ThemableMixin
        * @mixes Polymer.GestureEventListeners
        * @demo demo/index.html
@@ -247,16 +248,21 @@ This program is available under Apache License Version 2.0, available at https:/
               value: 'horizontal'
             },
 
+            /** @private */
             _previousPrimaryPointerEvents: String,
+
+            /** @private */
             _previousSecondaryPointerEvents: String
           };
         }
 
+        /** @protected */
         ready() {
           super.ready();
           new Polymer.FlattenedNodesObserver(this, this._processChildren);
         }
 
+        /** @protected */
         _processChildren() {
           this.getEffectiveChildren().forEach((child, i) => {
             if (i === 0) {
@@ -271,6 +277,7 @@ This program is available under Apache License Version 2.0, available at https:/
           });
         }
 
+        /** @private */
         _setFlexBasis(element, flexBasis, containerSize) {
           flexBasis = Math.max(0, Math.min(flexBasis, containerSize));
           if (flexBasis === 0) {
@@ -280,6 +287,7 @@ This program is available under Apache License Version 2.0, available at https:/
           element.style.flex = '1 1 ' + flexBasis + 'px';
         }
 
+        /** @private */
         _setPointerEventsNone(event) {
           if (!this._primaryChild || !this._secondaryChild) {
             return;
@@ -292,6 +300,7 @@ This program is available under Apache License Version 2.0, available at https:/
           event.preventDefault();
         }
 
+        /** @private */
         _restorePointerEvents() {
           if (!this._primaryChild || !this._secondaryChild) {
             return;
@@ -300,6 +309,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this._secondaryChild.style.pointerEvents = this._previousSecondaryPointerEvents;
         }
 
+        /** @private */
         _onHandleTrack(event) {
           if (!this._primaryChild || !this._secondaryChild) {
             return;

--- a/src/vaadin-split-layout.html
+++ b/src/vaadin-split-layout.html
@@ -241,6 +241,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return {
             /**
              * The split layout's orientation. Possible values are: `horizontal|vertical`.
+             * @type {!SplitLayoutOrientation}
              */
             orientation: {
               type: String,
@@ -262,7 +263,7 @@ This program is available under Apache License Version 2.0, available at https:/
           new Polymer.FlattenedNodesObserver(this, this._processChildren);
         }
 
-        /** @protected */
+        /** @private */
         _processChildren() {
           this.getEffectiveChildren().forEach((child, i) => {
             if (i === 0) {


### PR DESCRIPTION
Fixes #143 

Note, I couldn’t find a way to get correct types for `IronResizableBehavior`.
Tried `@implements {IronResizableBehavior}` but that didn’t help.

So, generated TS definitions look like this:

```ts
import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {GestureEventListeners} from '@polymer/polymer/lib/mixins/gesture-event-listeners.js';

import {FlattenedNodesObserver} from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';

import {IronResizableBehavior} from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {ElementMixin} from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';

declare class SplitLayoutElement extends
  ElementMixin(
  ThemableMixin(
  GestureEventListeners(
  PolymerElement))) {
  orientation: string|null|undefined;
  ready(): void;
  _processChildren(): void;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-split-layout": SplitLayoutElement;
  }
}

export {SplitLayoutElement};
```

**Question**: do we want to have custom types for `orientation` same as in list-mixin? 